### PR TITLE
データベース日付格納形式からDate型への変換を修正

### DIFF
--- a/src/modules/date.ts
+++ b/src/modules/date.ts
@@ -35,11 +35,12 @@ export const toDate = (dbFormat: number | string): Date => {
     dbFormat__str = dbFormat;
   }
 
-  const data = new Date();
-  data.setFullYear(Number.parseInt(dbFormat__str.substring(0, 4)));
-  data.setMonth(Number.parseInt(dbFormat__str.substring(4, 6)) - 1);
-  data.setDate(Number.parseInt(dbFormat__str.substring(6, 8)));
+  const year = Number.parseInt(dbFormat__str.substring(0, 4));
+  const month = Number.parseInt(dbFormat__str.substring(4, 6));
+  const date = Number.parseInt(dbFormat__str.substring(6, 8));
 
+  // year/month/date 00:00:00
+  const data = new Date(year, month - 1, date);
   return data;
 };
 


### PR DESCRIPTION
データベース日付格納形式からDate型へ変換する際の問題を修正しました。

これは、現在が31日であってかつ翌月に31日が存在しないときに、少なくとも発生します。

# 発生のメカニズム

https://kmc-jp.slack.com/archives/C0321SKJM/p1648688646312459 は以下のように発生します:



```
> x = new Date();
2022-03-31T02:38:18.479Z
> x.setFullYear(2022); x.toString();
'Thu Mar 31 2022 11:38:18 GMT+0900 (日本標準時)'
```

次の `setMonth()` を実行すると 2022年4月31日 つまり 2022年5月1日になります。

```
> x.setMonth(4-1); x.toString();
'Sun May 01 2022 11:38:18 GMT+0900 (日本標準時)'
```

これは7日に指定してもそのまま変わりません。
```
> x.setDate(7); x.toString();
'Sat May 07 2022 11:38:18 GMT+0900 (日本標準時)'
```

- これを防ぐためには、 `new Date()` のコンストラクタで一括して日付を指定すると良いです。
- なお、時刻部分はデータベースに格納されていないので、いっそのこと時刻を 00:00:00 固定に変更しました。
  - ここはこれで正しいのかやや自信がありません

以上、よろしくお願いいたします。
